### PR TITLE
Fixes increment to make it odd as required

### DIFF
--- a/benchmark/fillarray.c
+++ b/benchmark/fillarray.c
@@ -9,7 +9,7 @@ static uint32_t counter;
 void populateRandom_pcg32(uint32_t *answer, uint32_t size) {
   pcg32_random_t key = {
       .state = 324,
-      .inc = 4444}; // I am a crazy man using bleeding-edge C99 in 2018
+      .inc = 15}; // I am a crazy man using bleeding-edge C99 in 2018
   for (uint32_t i = 0; i < size; i++) {
     answer[i] = pcg32_random_r(&key);
   }


### PR DESCRIPTION
Hi! I just came across your blog post and checked out the source for the benchmarks.

That's when I noticed the increment in the scalar not being odd as it's required by the algorithm.

It's a small change and does not change any runtime results, it's just to make the pcg32 work correctly.